### PR TITLE
Fix failure on second apt install cmd on arm

### DIFF
--- a/Dockerfile.m
+++ b/Dockerfile.m
@@ -4,10 +4,30 @@ FROM --platform=linux/amd64 ubuntu:22.04
 
 ENV DEBIAN_FRONTEND noninteractive
 
-RUN apt update --fix-missing
-RUN apt install -y git gdb git wget patchelf file strace tmux python3 nasm binwalk bsdmainutils
-RUN apt install -y netcat python3-pip ruby-full valgrind vim xclip elfutils
-RUN apt install -y checksec
+RUN apt-get update --fix-missing && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+    git \
+    gdb \
+    wget \
+    patchelf \
+    file \
+    strace \
+    tmux \
+    python3 \
+    nasm \
+    binwalk \
+    bsdmainutils \
+    netcat \
+    python3-pip \
+    ruby-full \
+    valgrind \
+    vim \
+    xclip \
+    elfutils \
+    checksec \
+    ca-certificates && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
 
 WORKDIR /opt
 RUN git clone https://github.com/pwndbg/pwndbg
@@ -16,8 +36,8 @@ ENV LC_ALL=C.UTF-8
 RUN ./setup.sh
 
 WORKDIR /opt
-RUN wget https://github.com/io12/pwninit/releases/download/3.3.0/pwninit
-RUN chmod +x pwninit
+RUN wget https://github.com/io12/pwninit/releases/download/3.3.0/pwninit && \
+    chmod +x pwninit
 
 RUN gem install one_gadget
 RUN pip3 install IPython icecream angr pwntools

--- a/Dockerfile.m
+++ b/Dockerfile.m
@@ -2,10 +2,10 @@ FROM --platform=linux/amd64 ubuntu:22.04
 
 #https://wiki.ubuntu.com/Releases
 
-ENV DEBIAN_FRONTEND noninteractive
+ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update --fix-missing && \
-    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+    apt-get install -y --no-install-recommends \
     git \
     gdb \
     wget \
@@ -43,4 +43,4 @@ RUN gem install one_gadget
 RUN pip3 install IPython icecream angr pwntools
 
 WORKDIR /home/localdir
-CMD bash
+CMD ["bash"]


### PR DESCRIPTION
Got the following Error while trying to build the Dockerfile on an Apple arm m2 chip.
Fixed it by combining everything into one cmd and add ca-certificates.

Also fixed two deprecated warnings from docker:
```
3 warnings found (use docker --debug to expand):
 - FromPlatformFlagConstDisallowed: FROM --platform flag should not use constant value "linux/amd64" (line 1)
 - LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 5)
 - JSONArgsRecommended: JSON arguments recommended for CMD to prevent unintended behavior related to OS signals (line 26)
Dockerfile.m:8
```

```
	Setting up python3-matplotlib (3.5.1-2build1) ...
	Setting up libgtk-3-0:amd64 (3.24.33-1ubuntu2.2) ...
	Setting up libgtk-3-bin (3.24.33-1ubuntu2.2) ...
	Setting up qt5-gtk-platformtheme:amd64 (5.15.3+dfsg-2ubuntu0.2) ...
	Setting up ri (1:3.0~exp1) ...
	Setting up ruby (1:3.0~exp1) ...
	Setting up humanity-icon-theme (0.6.16) ...
	Setting up rake (13.0.6-2) ...
	Setting up libruby3.0:amd64 (3.0.2-7ubuntu2.8) ...
	Setting up ubuntu-mono (20.10-0ubuntu2) ...
	Setting up ruby-rubygems (3.3.5-2) ...
	Setting up ruby3.0-dev:amd64 (3.0.2-7ubuntu2.8) ...
	Setting up ruby-dev:amd64 (1:3.0~exp1) ...
	Setting up ruby-full (1:3.0~exp1) ...
	Processing triggers for libc-bin (2.35-0ubuntu3.8) ...
	Processing triggers for ca-certificates (20240203~22.04.1) ...
	Updating certificates in /etc/ssl/certs...
	0 added, 0 removed; done.
	Running hooks in /etc/ca-certificates/update.d...
	done.
	Processing triggers for libgdk-pixbuf-2.0-0:amd64 (2.42.8+dfsg-1ubuntu0.3) ...
	Errors were encountered while processing:
	python3-dbus
	networkd-dispatcher
	E: Sub-process /usr/bin/dpkg returned an error code (1)
```